### PR TITLE
Flaky test fix: LinkedHashMap instead of HashMap

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java
@@ -38,6 +38,7 @@ import java.security.SignatureException;
 import java.text.ParseException;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -86,7 +87,7 @@ public class AuthenticationToken {
         }
 
         Map<String, Object> toMap() {
-            final Map<String, Object> headerMap = new HashMap<>(3, 1);
+            final Map<String, Object> headerMap = new LinkedHashMap<>(3, 1);
             headerMap.put("alg", "ES256");
             headerMap.put("typ", "JWT");
             headerMap.put("kid", this.keyId);
@@ -129,7 +130,7 @@ public class AuthenticationToken {
         }
 
         Map<String, Object> toMap() {
-            final Map<String, Object> headerMap = new HashMap<>(2, 1);
+            final Map<String, Object> headerMap = new LinkedHashMap<>(2, 1);
             headerMap.put("iss", this.issuer);
             headerMap.put("iat", this.issuedAt.getEpochSecond());
 


### PR DESCRIPTION
This PR aims to fix 11 flaky tests:
```
com.eatthepath.pushy.apns.ApnsClientTest#testSendNotification
com.eatthepath.pushy.apns.ApnsClientTest#testSendNotificationWithPushTypeHeader
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithEmptyPayload
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithCollapseId
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithExpirationDate
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithSpecifiedPriority
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithMissingPayload
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithOversizedPayload
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithWithExpiredAuthenticationToken
com.eatthepath.pushy.apns.auth.AuthenticationTokenTest#testVerifySignature
com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithValidNotification
```
The below analysis is for one of these cases: `testHandleNotificationWithWithExpiredAuthenticationToken`. The same fix fixed 10 other flaky tests.

In the test case [`testHandleNotificationWithWithExpiredAuthenticationToken`](https://github.com/KiruthikaJanakiraman/pushy/blob/deec0642ce63d86ca0572a245112c16603123902/pushy/src/test/java/com/eatthepath/pushy/apns/server/TokenAuthenticationValidatingPushNotificationHandlerTest.java#L169C1-L180), an expired token is initialised using the constructor of [`AuthenticationToken.java`](https://github.com/KiruthikaJanakiraman/pushy/blob/main/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java#L66). This method uses a function called [`toMap()`](https://github.com/KiruthikaJanakiraman/pushy/blob/da5f8b97106cd41278b421ec63e4e76a7313bed9/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java#L88-L96) which makes use of a `HashMap` to form the signature `signatureBytes`. This signature is verified using a [`verify`](https://github.com/KiruthikaJanakiraman/pushy/blob/da5f8b97106cd41278b421ec63e4e76a7313bed9/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java#L293) function.
Since HashMap does not guarantee the order of the items in the map, the signature may suffer from non-determinism, causing the verify function to fail, making the test flaky.

I found and confirmed the flaky behavior using an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which shuffles implementations of nondeterminism operations.

This PR fixes the test by replacing `HashMap` with `LinkedHashMap`. Since `LinkedHashMap` retains the order of insertion, this fixed the flakiness of the test.

The following command can be used to reproduce assertion failures and verify the fix:
```
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -pl broker -Dtest=com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithWithExpiredAuthenticationToken
```

This line invokes the `toMap()` function:
https://github.com/KiruthikaJanakiraman/pushy/blob/da5f8b97106cd41278b421ec63e4e76a7313bed9/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java#L158

The `toMap()` function creates a `HashMap` here:
https://github.com/KiruthikaJanakiraman/pushy/blob/da5f8b97106cd41278b421ec63e4e76a7313bed9/pushy/src/main/java/com/eatthepath/pushy/apns/auth/AuthenticationToken.java#L132

The assertion happens here:
https://github.com/KiruthikaJanakiraman/pushy/blob/da5f8b97106cd41278b421ec63e4e76a7313bed9/pushy/src/test/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandlerTest.java#L273

Test Environment:
```
openjdk version "11.0.20.1"
Apache Maven 3.6.3
Ubuntu 20.04.6 LTS
Linux version 5.4.0-156-generic
```


Please let me know if you have any concerns or questions.